### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server that provides curl functionality, allowing AI assistants to make HTTP requests directly from their environment.
 
+<a href="https://glama.ai/mcp/servers/@247arjun/mcp-curl">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@247arjun/mcp-curl/badge" alt="Curl Server MCP server" />
+</a>
+
 ## Features
 
 - **HTTP Methods**: Support for GET, POST, PUT, DELETE requests


### PR DESCRIPTION
This PR adds a badge for the [Curl MCP Server](https://glama.ai/mcp/servers/@247arjun/mcp-curl) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@247arjun/mcp-curl">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@247arjun/mcp-curl/badge" alt="Curl Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.